### PR TITLE
Bf first spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 Changelog
 =========
 
-## 0.1.0 10/07/2019
+## 0.1.0 10/10/2019
   * Instrumention for open tracing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+Changelog
+=========
+
+## 0.1.0 10/07/2019
+  * Instrumention for open tracing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,23 @@ PATH
   remote: .
   specs:
     graphql-opentracing (0.1.0)
+      activesupport
       opentracing (~> 0.5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     graphql (1.9.12)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
     opentracing (0.5.0)
     rake (10.5.0)
     rspec (3.8.0)
@@ -24,6 +34,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: .
+  specs:
+    graphql-opentracing (0.1.0)
+      opentracing (~> 0.5.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    graphql (1.9.12)
+    opentracing (0.5.0)
+    rake (10.5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.0)
+  graphql
+  graphql-opentracing!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-opentracing (0.1.0.pre)
+    graphql-opentracing (0.1.0)
       activesupport
       opentracing (~> 0.5.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-opentracing (0.1.0)
+    graphql-opentracing (0.1.0.pre)
       activesupport
       opentracing (~> 0.5.0)
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,17 @@ If you have setup `OpenTracing.global_tracer` you can turn on spans for all requ
     GraphQL::Tracer.instrument
 ```
 
-Under the hood the gem subscribes to graphql instrumentation events through ActiveSupport notifications framework. If you find the number of spans too noisy you can control which spans are reported though a callback like:
+You must also modify your GQL schema to add the ActiveSupportNotifications tracer provided by the GQL gem
+
+```
+tracer(GraphQL::Tracing::ActiveSupportNotificationsTracing)
+```
+
+Under the hood this gem subscribes to graphql instrumentation events through the ActiveSupport notifications framework. If you find the number of spans too noisy you can control which spans are reported though a callback like:
 ```
 GraphQl::Tracer.instrument(
     tracer: tracer,
-    ignore_request: ->(name, started, finished, id, data) {  name == 'graphql.lex' }
+    ignore_request: ->(name, started, finished, id, data) { !name.include? 'execute_query' }
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Graphql::Opentracing
+# Graphql Opentracing
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/graphql/opentracing`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Open Tracing instrumentation for the [graphql gem](https://github.com/rmosolgo/graphql-ruby). By default it starts a new span for every request handled by graphql. It follows the open tracing tagging [semantic conventions](https://opentracing.io/specification/conventions)
 
 ## Installation
 
@@ -21,18 +19,31 @@ Or install it yourself as:
     $ gem install graphql-opentracing
 
 ## Usage
+First load the opentracing (Note: this won't automatically instrument the graphql gem)
+```
+require "graphql-opentracing"
+```
 
-TODO: Write usage instructions here
+If you have setup `OpenTracing.global_tracer` you can turn on spans for all requests with just:
+```
+    Graphql::Tracer.instrument
+```
+
+Under the hood the gem subscribes to graphql instrumentation events through ActiveSupport notifications framework. If you find the number of spans too noisy you can control which spans are reported though a callback like:
+```
+Graphql::Tracer.instrument(
+    tracer: tracer,
+    ignore_request: ->(name, started, finished, id, data) {  name == 'graphql.lex' }
+)
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+After checking out the repo, run `bundle install` to install dependencies. Then, run `rspec` to run the tests.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/graphql-opentracing. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/benedictfischer09/ruby-graphql-instrumentation. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -40,4 +51,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Graphql::Opentracing project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/graphql-opentracing/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/benedictfischer09/ruby-graphql-instrumentation/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ GraphQl::Tracer.instrument(
 )
 ```
 
+If you have a bespoke way of passing errors in the response that is not part of context errors you can detect errors for tagging your spans through a callback:
+```
+GraphQl::Tracer.instrument(
+    tracer: tracer,
+    check_errors: ->(name, started, finished, id, data) { data[:context] == "whatever" }
+)
+```
+
 ## Development
 
 After checking out the repo, run `bundle install` to install dependencies. Then, run `rspec` to run the tests.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Graphql Opentracing
+# GraphQL Opentracing
 
 Open Tracing instrumentation for the [graphql gem](https://github.com/rmosolgo/graphql-ruby). By default it starts a new span for every request handled by graphql. It follows the open tracing tagging [semantic conventions](https://opentracing.io/specification/conventions)
 
@@ -26,12 +26,12 @@ require "graphql-opentracing"
 
 If you have setup `OpenTracing.global_tracer` you can turn on spans for all requests with just:
 ```
-    Graphql::Tracer.instrument
+    GraphQL::Tracer.instrument
 ```
 
 Under the hood the gem subscribes to graphql instrumentation events through ActiveSupport notifications framework. If you find the number of spans too noisy you can control which spans are reported though a callback like:
 ```
-Graphql::Tracer.instrument(
+GraphQl::Tracer.instrument(
     tracer: tracer,
     ignore_request: ->(name, started, finished, id, data) {  name == 'graphql.lex' }
 )

--- a/graphql-opentracing.gemspec
+++ b/graphql-opentracing.gemspec
@@ -4,7 +4,7 @@ require "graphql/opentracing/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "graphql-opentracing"
-  spec.version       = Graphql::Opentracing::VERSION
+  spec.version       = GraphQL::Opentracing::VERSION
   spec.authors       = ["Ben Fischer"]
   spec.email         = ["ben.fischer.810@gmail.com"]
 
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "opentracing", "~> 0.5.0"
+  spec.add_dependency "activesupport"
   spec.add_development_dependency "graphql"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/graphql-opentracing.gemspec
+++ b/graphql-opentracing.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/benedictfischer09/ruby-graphql-instrumentation"
   spec.metadata["changelog_uri"] = "https://github.com/benedictfischer09/ruby-graphql-instrumentation/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.

--- a/graphql-opentracing.gemspec
+++ b/graphql-opentracing.gemspec
@@ -8,16 +8,16 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ben Fischer"]
   spec.email         = ["ben.fischer.810@gmail.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{Instruments the graphql-ruby gem for opentracing}
+  spec.description   = %q{Instruments the graphql-ruby gem for opentracing}
+  spec.homepage      = "https://github.com/benedictfischer09/ruby-grqphql-instrumentation"
   spec.license       = "MIT"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["changelog_uri"] = "https://github.com/benedictfischer09/ruby-graphql-instrumentation/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "opentracing", "~> 0.5.0"
+  spec.add_development_dependency "graphql"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/graphql-opentracing.rb
+++ b/lib/graphql-opentracing.rb
@@ -1,0 +1,1 @@
+require 'graphql/tracer'

--- a/lib/graphql/opentracing.rb
+++ b/lib/graphql/opentracing.rb
@@ -1,8 +1,0 @@
-require "graphql/opentracing/version"
-
-module Graphql
-  module Opentracing
-    class Error < StandardError; end
-    # Your code goes here...
-  end
-end

--- a/lib/graphql/opentracing/version.rb
+++ b/lib/graphql/opentracing/version.rb
@@ -1,4 +1,4 @@
-module Graphql
+module GraphQL
   module Opentracing
     VERSION = "0.1.0"
   end

--- a/lib/graphql/opentracing/version.rb
+++ b/lib/graphql/opentracing/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Opentracing
-    VERSION = "0.1.0.pre"
+    VERSION = "0.1.0"
   end
 end

--- a/lib/graphql/opentracing/version.rb
+++ b/lib/graphql/opentracing/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Opentracing
-    VERSION = "0.1.0"
+    VERSION = "0.1.0.pre"
   end
 end

--- a/lib/graphql/tracer.rb
+++ b/lib/graphql/tracer.rb
@@ -21,17 +21,12 @@ module GraphQL
         @ignore_request = ignore_request
         @check_errors = check_errors
         @tracer = tracer
-        install_active_support_notifications
         subscribe_active_support_notifications
       end
 
       def compatible_version?
         # support for ActiveSupportNotificationsTracing
         Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.7.0')
-      end
-
-      def install_active_support_notifications
-        GraphQL::Tracing.install(GraphQL::Tracing::ActiveSupportNotificationsTracing)
       end
 
       def subscribe_active_support_notifications

--- a/lib/graphql/tracer.rb
+++ b/lib/graphql/tracer.rb
@@ -1,0 +1,55 @@
+require 'graphql/opentracing/version'
+require 'active_support'
+
+module GraphQL
+  module Tracer
+    class IncompatibleGemVersion < StandardError; end;
+
+    class << self
+      attr_accessor :ignore_request, :tracer
+
+      IgnoreRequest = ->(_name, _started, _finished, _id, _data) { false }
+
+      def instrument(tracer: OpenTracing.global_tracer, ignore_request: IgnoreRequest)
+        begin
+          require 'graphql'
+        rescue LoadError
+          return
+        end
+        raise IncompatibleGemVersion unless compatible_version?
+
+        @ignore_request = ignore_request
+        @tracer = tracer
+        install_active_support_notifications
+        subscribe_active_support_notifications
+      end
+
+      def compatible_version?
+        # support for ActiveSupportNotificationsTracing
+        Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.7.0')
+      end
+
+      def install_active_support_notifications
+        GraphQL::Tracing.install(GraphQL::Tracing::ActiveSupportNotificationsTracing)
+      end
+
+      def subscribe_active_support_notifications
+        ActiveSupport::Notifications.subscribe(/^graphql/) do |name, started, finished, id, data|
+          next if @ignore_request.call(name, started, finished, id, data)
+
+          tags = {
+            "component" => "ruby-graphql",
+            "span.kind" => "server",
+            "operation" => name
+          }
+          span = tracer.start_span("graphql",
+            tags: tags,
+            start_time: started)
+
+          span.set_tag("error", true) if data[:context]&.errors&.any? # TODO best way to detect errors
+          span.finish(end_time: finished)
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/opentracing_spec.rb
+++ b/spec/graphql/opentracing_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe Graphql::Opentracing do
-  it "has a version number" do
-    expect(Graphql::Opentracing::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
-end

--- a/spec/graphql/tracer_spec.rb
+++ b/spec/graphql/tracer_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'graphql'
+require 'opentracing'
+
+class QueryType < GraphQL::Schema::Object
+  graphql_name 'Query'
+
+  field :hello, String, null: true
+  def hello
+    'hello world!'
+  end
+end
+class SampleSchema < GraphQL::Schema
+  query(QueryType)
+end
+
+RSpec.describe GraphQL::Tracer do
+  describe '.instrument' do
+    it 'adds active support instrumentation' do
+      expect do
+        described_class.instrument
+      end.to change(GraphQL::Tracing.tracers, :count).by(1)
+    end
+
+    it 'detects existing active support instrumentation' do
+      GraphQL::Tracing.install(GraphQL::Tracing::ActiveSupportNotificationsTracing)
+
+      expect do
+        described_class.instrument
+      end.not_to change(GraphQL::Tracing.tracers, :count)
+    end
+
+    context 'with instrumented schema' do
+      let(:query_string) do
+        <<-GRAPHQL
+        query greeting {
+          hello
+        }
+        GRAPHQL
+      end
+
+      it 'start and finshes a span for a GQL event' do
+        span = double(finish: true)
+        tracer = double(start_span: span)
+        described_class.instrument(tracer: tracer)
+        execute_query(query_string)
+        expect(tracer).to have_received(:start_span).at_least(:once)
+        expect(span).to have_received(:finish).at_least(:once)
+      end
+
+      it 'can be configured to skip creating a span for some events' do
+        span = double(finish: true)
+        tracer = double(start_span: span)
+        described_class.instrument(
+          tracer: tracer,
+          ignore_request: ->(name, _started, _finished, _id, _data) { name.include?('graphql') }
+        )
+
+        execute_query(query_string)
+        expect(tracer).not_to have_received(:start_span)
+        expect(span).not_to have_received(:finish)
+      end
+
+      it 'follows semantic conventions for the span tags' do
+        span = double(finish: true)
+        tracer = double(start_span: span)
+        described_class.instrument(tracer: tracer)
+        execute_query(query_string)
+
+        expect(tracer).to have_received(:start_span).with(
+          'graphql',
+          start_time: anything,
+          tags: {
+            'component' => 'ruby-graphql',
+            'span.kind' => 'server',
+            'operation' => 'graphql.execute_query'
+          }
+        ).at_least(:once)
+      end
+
+      xit 'tags the span as an error when the response is an error' do
+        span = double(finish: true, set_tag: true)
+        tracer = double(start_span: span)
+        described_class.instrument(tracer: tracer)
+        execute_query(query_string, context: { errors: ['a'] })
+
+        expect(span).to have_received(:set_tag).at_least(:once)
+      end
+    end
+
+    def execute_query(string, variables = {}, context: {})
+      GraphQL::Query.new(SampleSchema, string, variables: variables, context: context).result
+    end
+  end
+end

--- a/spec/graphql/tracer_spec.rb
+++ b/spec/graphql/tracer_spec.rb
@@ -13,24 +13,11 @@ class QueryType < GraphQL::Schema::Object
 end
 class SampleSchema < GraphQL::Schema
   query(QueryType)
+  tracer(GraphQL::Tracing::ActiveSupportNotificationsTracing)
 end
 
 RSpec.describe GraphQL::Tracer do
   describe '.instrument' do
-    it 'adds active support instrumentation' do
-      expect do
-        described_class.instrument
-      end.to change(GraphQL::Tracing.tracers, :count).by(1)
-    end
-
-    it 'detects existing active support instrumentation' do
-      GraphQL::Tracing.install(GraphQL::Tracing::ActiveSupportNotificationsTracing)
-
-      expect do
-        described_class.instrument
-      end.not_to change(GraphQL::Tracing.tracers, :count)
-    end
-
     context 'with instrumented schema' do
       let(:query_string) do
         <<-GRAPHQL

--- a/spec/graphql/tracer_spec.rb
+++ b/spec/graphql/tracer_spec.rb
@@ -79,10 +79,13 @@ RSpec.describe GraphQL::Tracer do
         ).at_least(:once)
       end
 
-      xit 'tags the span as an error when the response is an error' do
+      it 'tags the span as an error when the response includes an error' do
         span = double(finish: true, set_tag: true)
         tracer = double(start_span: span)
-        described_class.instrument(tracer: tracer)
+        described_class.instrument(
+          tracer: tracer,
+          check_errors: -> (_name, _started, _finished, _id, data) { true }
+        )
         execute_query(query_string, context: { errors: ['a'] })
 
         expect(span).to have_received(:set_tag).at_least(:once)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "graphql/opentracing"
+require "graphql/tracer"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
The GQL ruby gem provides a way to install custom tracers.

It also provides an out of the box tracer (starting in version 1.7.0) for hooking its events into Active Support Notifications.

This instrumentation sets up that tracer and hooks into the events from there