### PR TITLE
Move away from ActiveSupport to custom tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
 
+## 0.2.0 10/29/2019
+  * Move instrumentation off ActiveSupport onto the custom tracer framework
+
 ## 0.1.0 10/10/2019
   * Instrumention for open tracing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,14 @@
 PATH
   remote: .
   specs:
-    graphql-opentracing (0.1.0)
-      activesupport
+    graphql-opentracing (0.2.0.pre)
       opentracing (~> 0.5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     graphql (1.9.12)
-    i18n (1.6.0)
-      concurrent-ruby (~> 1.0)
-    minitest (5.11.3)
     opentracing (0.5.0)
     rake (10.5.0)
     rspec (3.8.0)
@@ -34,9 +24,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-opentracing (0.2.0.pre)
+    graphql-opentracing (0.2.0)
       opentracing (~> 0.5.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -38,16 +38,9 @@ tracer(GraphQL::Tracing::ActiveSupportNotificationsTracing)
 Under the hood this gem subscribes to graphql instrumentation events through the ActiveSupport notifications framework. If you find the number of spans too noisy you can control which spans are reported though a callback like:
 ```
 GraphQl::Tracer.instrument(
+    schema: MyGQLSchema,
     tracer: tracer,
     ignore_request: ->(name, started, finished, id, data) { !name.include? 'execute_query' }
-)
-```
-
-If you have a bespoke way of passing errors in the response that is not part of context errors you can detect errors for tagging your spans through a callback:
-```
-GraphQl::Tracer.instrument(
-    tracer: tracer,
-    check_errors: ->(name, started, finished, id, data) { data[:context] == "whatever" }
 )
 ```
 

--- a/graphql-opentracing.gemspec
+++ b/graphql-opentracing.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "opentracing", "~> 0.5.0"
-  spec.add_dependency "activesupport"
   spec.add_development_dependency "graphql"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/graphql/opentracing/version.rb
+++ b/lib/graphql/opentracing/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Opentracing
-    VERSION = "0.1.0"
+    VERSION = "0.2.0.pre"
   end
 end

--- a/lib/graphql/opentracing/version.rb
+++ b/lib/graphql/opentracing/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Opentracing
-    VERSION = "0.2.0.pre"
+    VERSION = "0.2.0"
   end
 end

--- a/lib/graphql/tracer.rb
+++ b/lib/graphql/tracer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'graphql/opentracing/version'
-require 'active_support'
 
 module GraphQL
   module Tracer

--- a/lib/graphql/tracer.rb
+++ b/lib/graphql/tracer.rb
@@ -1,16 +1,19 @@
+# frozen_string_literal: true
+
 require 'graphql/opentracing/version'
 require 'active_support'
 
 module GraphQL
   module Tracer
-    class IncompatibleGemVersion < StandardError; end;
+    class IncompatibleGemVersion < StandardError; end
 
     class << self
       attr_accessor :ignore_request, :tracer
 
-      IgnoreRequest = ->(_name, _started, _finished, _id, _data) { false }
-      CheckErrors = -> (_name, _started, _finished, _id, data) { data[:context]&.errors&.any? }
-      def instrument(tracer: OpenTracing.global_tracer, ignore_request: IgnoreRequest, check_errors: CheckErrors)
+      IgnoreRequest = ->(_name, _metadata) { false }
+
+      def instrument(schema: nil, tracer: OpenTracing.global_tracer,
+                     ignore_request: IgnoreRequest)
         begin
           require 'graphql'
         rescue LoadError
@@ -18,10 +21,10 @@ module GraphQL
         end
         raise IncompatibleGemVersion unless compatible_version?
 
+        @schema = schema
         @ignore_request = ignore_request
-        @check_errors = check_errors
         @tracer = tracer
-        subscribe_active_support_notifications
+        install_tracer
       end
 
       def compatible_version?
@@ -29,21 +32,23 @@ module GraphQL
         Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.7.0')
       end
 
-      def subscribe_active_support_notifications
-        ActiveSupport::Notifications.subscribe(/^graphql/) do |name, started, finished, id, data|
-          next if @ignore_request.call(name, started, finished, id, data)
+      def install_tracer
+        @schema.tracer self if @schema
+      end
 
-          tags = {
-            "component" => "ruby-graphql",
-            "span.kind" => "server",
-            "operation" => name
-          }
-          span = tracer.start_span("graphql",
-            tags: tags,
-            start_time: started)
+      def trace(key, metadata)
+        return yield if @ignore_request.call(key, metadata)
 
-          span.set_tag("error", true) if @check_errors.call(name, started, finished, id, data)
-          span.finish(end_time: finished)
+        @tracer.start_active_span("graphql.#{key}", tags: {
+                                    'component' => 'ruby-graphql',
+                                    'span.kind' => 'server'
+                                  }) do |scope|
+          begin
+            yield
+          rescue StandardError
+            scope.span.set_tag('error', true)
+            raise
+          end
         end
       end
     end


### PR DESCRIPTION
ActiveSupport is a good framework for tracking events but by design the subscriber doesn't get notified of the event until after it is finished.  This creates a problem for open tracing because child spans created during the parent span aren't linked automatically since the parent span is not active while the work is being done. 

The custom tracer framework gives us a hook around the actual GQL work which means the parent span will be active the entire time that real work happens.